### PR TITLE
Kurulum ve Kullanım Doküman Linkini Onar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 **Buna benzer bir site oluşturmak için bu depoyu "fork" etmek yerine lütfen
-[kurulum ve kullanım dokümanında](http://fo.roktas.me/fo-intro) açıklanan
+[kurulum ve kullanım dokümanında](http://r.oktas.us/fo/fo-intro/) açıklanan
 talimatları izleyin.**


### PR DESCRIPTION
README dosyasındaki kurulum ve kullanım dokümanı için verilen bağlantı , ilgili folyonun adresi değiştiği için kırık link haline gelmiş. Kırık linki yeni geçerli link olan [http://r.oktas.us/fo/fo-intro/](http://r.oktas.us/fo/fo-intro/) ile değiştirdim.